### PR TITLE
fix: remove markdown formatting from subject field in chat interface

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -593,7 +593,7 @@ elif page == "💬 Chat Agent":
             st.error("RAG pipeline not initialized. Please check your configuration.")
         else:
             # Format the user message
-            user_message = f"**Subject:** {subject}\n\n{message}" if subject else message
+            user_message = f"Subject: {subject}\n\n{message}" if subject else message
 
             # Add user message to UI
             st.session_state.messages.append({


### PR DESCRIPTION
Remove bold markdown syntax (**) from subject display to show plain text instead of formatted text in chat messages.